### PR TITLE
Add example project and Dockerfile for Node dev

### DIFF
--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -1,0 +1,54 @@
+# Sets the base image
+FROM node:8.4.0
+
+# Use an env var to hold what will be the main directory within the container.
+# As we need to refer to it a few times it can be easier to set an env var
+# and then refer to it in subsequent commands
+ENV APP_HOME /app
+
+# This will execute any commands in a new layer on top of the current image and
+# commit the results. In this case we create the /app directory
+RUN mkdir $APP_HOME
+
+# Sets the working directory for any RUN, CMD, ENTRYPOINT, COPY and ADD
+# instructions that follow it
+WORKDIR $APP_HOME
+
+# Copies new files or directories from <src> and adds them to the filesystem of
+# the container at the path <dest>
+COPY ./package.json $APP_HOME
+
+# Here we tell docker to download our projects dependencies, then move that
+# folder to the root (why explained below) in another layer that then gets
+# committed
+RUN npm install \
+    && mv $APP_HOME/node_modules /node_modules
+
+# ##############################################################################
+# Npm unlike Bundler defaults to installing dependencies within the local
+# project. That's fine when developing on the host, but as we want to install
+# them as part of the image and have them present in the container when we start
+# developing we face a problem.
+#
+# To use the container for development we mount the project folder to /app when
+# calling `docker run`. If the container's app folder still held `node_modules`,
+# the bind would cause it to become hidden as it doesn't exist on the host. We
+# therefore need to move the `node_modules` somewhere else, in this case the
+# root.
+#
+# In doing so we take advantage of
+# https://nodejs.org/api/modules.html#modules_loading_from_node_modules_folders
+# and the way Node.js traverses the directory tree to locate dependencies.
+# ##############################################################################
+
+# Informs Docker that the container should listen on the specified network port
+# at runtime. EXPOSE does not make the ports of the container accessible to the
+# host. To do that, you must use still use the `docker run` -p flag
+EXPOSE 3000
+
+# There can only be one CMD instruction in a Dockerfile. If you list more than
+# one CMD then only the last CMD will take effect.
+
+# Purpose of a CMD is to provide defaults for an executing container. In this
+# case it sets the command and arguments to be executed when running the image
+CMD ["/node_modules/.bin/nodemon", "server.js"]

--- a/node/README.md
+++ b/node/README.md
@@ -1,3 +1,50 @@
 # Using Docker for node development
 
 A basic example of using **Docker** to provide an environment in which you can run and work on your Node.js app.
+
+Specifically in this case we have an [Express](https://expressjs.com/) application with a simple root `GET`, which returns `Hello world` as we want to demonstrate a very basic app that
+
+- has a dependency and so needs a `package.json`
+- has something we can interact with from the host
+- is basic enough that it won't complicate what we're trying to show in **Docker**
+
+## Build
+
+Assuming what is in this folder represents the project in question, having cloned it locally the first step would be to create an image from it.
+
+```bash
+docker build -t docker-for-node-dev .
+```
+
+Having run this on a machine clean of other **Docker** images running `docker images` would result in something like
+
+```bash
+REPOSITORY            TAG                 IMAGE ID            CREATED             SIZE
+docker-for-node-dev   latest              c7c5150e2d55        2 minutes ago       677MB
+node                  8.4.0               5e553613f1d8        17 hours ago        669MB
+```
+## Run
+
+Now we have an image, we want to create and run a container from it
+
+```bash
+docker run --rm -v "$(pwd)":/app -w /app -p 3000:3000 docker-for-node-dev
+```
+
+Breaking down this command we have
+
+- `docker run` first creates a writeable container layer over the specified image, and then starts it using the specified command
+- `--rm` automatically removes the container on exit
+- `-v "$(pwd)":/app` mounts the local folder to `/app` in the container
+- `-p 3000:3000` bind port 3000 on the host to 3000 in the container <host:container>
+- `docker-for-ruby-dev` the specified image to create and run a container from
+
+Running in this way ensures we see any output from our app. Add the `-d` flag if you prefer the container to run as a daemon.
+
+## Develop
+
+Now we have a container we want to be able to make changes. As we have mounted the project's root folder to `/app` in the container we can open it in our preferred editor, make changes, and see them reflected in the app.
+
+To prove this using our demo project first run `curl -XGET http://localhost:3000` from the host. The response should be `Hello world`.
+
+Edit `server.js` and change line 5 to be `res.send('Hello docker world')`. Running the same `curl` command again should result in `Hello docker world`.

--- a/node/package.json
+++ b/node/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "docker-for-node-dev",
+  "version": "0.1.0",
+  "description": "Example site used to demo Docker for node development",
+  "homepage": "https://github.com/Cruikshanks/docker-for-dev",
+  "license": "MIT",
+  "author": {
+    "name": "Alan Cruikshanks",
+    "url": "https://github.com/Cruikshanks"
+  },
+  "private": true,
+  "scripts": {
+    "start": "nodemon server.js"
+  },
+  "dependencies": {
+    "express": "^4.15.4"
+  },
+  "devDependencies": {
+    "nodemon": "^1.11.0"
+  }
+}

--- a/node/server.js
+++ b/node/server.js
@@ -1,0 +1,10 @@
+const express = require('express')
+const app = express()
+
+app.get('/', function (req, res) {
+  res.send('Hello world')
+})
+
+app.listen(3000, function () {
+  console.log('Example app listening on port 3000!')
+})


### PR DESCRIPTION
This mirrors as close as possible an example project and `Dockerfile` like the one used for ruby.

It also updates the README.md in `/node` with details on building, running and developing using the container.

Finally we update the project README to cover the fact we now have a Node.js example.